### PR TITLE
Fixed typo variable name

### DIFF
--- a/data/part-1/3-more-about-variables.md
+++ b/data/part-1/3-more-about-variables.md
@@ -148,7 +148,7 @@ number1 = 100
 number2 = "100"
 
 print(number1)
-print(numbers2)
+print(number2)
 ```
 
 <sample-output>


### PR DESCRIPTION
print function used incorrect variable name.