### PR TITLE
Fixing a typo in Part-4/6-strings-and-lists

### DIFF
--- a/data/part-4/6-strings-and-lists.md
+++ b/data/part-4/6-strings-and-lists.md
@@ -504,7 +504,7 @@ The program asks the user for results from different students on the course. The
 
 Exam points are integers between 0 and 20. The number of exercises completed is an integer between 0 and 100.
 
-The program kees asking for input until the user types in an empty line. You may assume all lines contain valid input, which means that there are two integers on each line, or the line is empty.
+The program keeps asking for input until the user types in an empty line. You may assume all lines contain valid input, which means that there are two integers on each line, or the line is empty.
 
 And example of how the data is typed in:
 


### PR DESCRIPTION
Changed "kees" to "keeps"